### PR TITLE
RESOLVE THE ISSUE : Type error: Property 'portCode' is missing in typ…

### DIFF
--- a/app/(routes)/[organizationId]/documentation/parties/components/CbNameCellAction.tsx
+++ b/app/(routes)/[organizationId]/documentation/parties/components/CbNameCellAction.tsx
@@ -30,6 +30,7 @@ interface CbName {
   mobileNo: number;
   email: string;
   organizationId: string;
+  portCode: string; // Added missing property
 }
 
 interface Props {


### PR DESCRIPTION
…e 'CbName' but required in type 'CBData'.